### PR TITLE
Add Google Analytics script

### DIFF
--- a/src/templates/head.twig
+++ b/src/templates/head.twig
@@ -36,4 +36,14 @@
   media="screen"
 />
 
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-142020665-2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-142020665-2');
+</script>
+
 {{ function('wp_head') }}


### PR DESCRIPTION
Add Google Analytics script to Timber head template, ensuring it will appear on every page. This will also allow us to use Google Search Console with the site.