### PR TITLE
Don't scroll down on homepage on "Work With Us"

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,16 +4,6 @@
 // everything in this file will be run on every page
 
 $(function() {
-  // Homepage: scroll to about from hero
-  $('#hero .cta .btn').click(function() {
-    $([document.documentElement, document.body]).animate(
-      {
-        scrollTop: $('#about').offset().top - 80,
-      },
-      800
-    );
-  });
-
   // Application page: scroll to application list
   $('#apply-hero .cta .btn').click(function() {
     $([document.documentElement, document.body]).animate(


### PR DESCRIPTION
Remove JS code that caused page to scroll down when "Work With Us"
button was clicked.